### PR TITLE
Publish v2.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: publish
+
+on:
+  push:
+    branches: [ production ]
+
+jobs:
+  build:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Publish
+        run: bash ./gradlew :calendarext:publish

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'com.ltman:calendar-ext:1.0.5'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
 
     implementation 'com.google.android.material:material:1.4.0'

--- a/calendarext/build.gradle
+++ b/calendarext/build.gradle
@@ -11,6 +11,9 @@ android {
         minSdkVersion 16
         targetSdkVersion 30
 
+        versionCode 12
+        versionName "2.0.0"
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }
@@ -33,7 +36,7 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.7.0'


### PR DESCRIPTION
- Allow user to mock current time globally with `CalendarExt.currentTime`